### PR TITLE
dev-util/codelite-11.0: bump to EAPI6 and fix depends

### DIFF
--- a/dev-util/codelite/codelite-11.0.ebuild
+++ b/dev-util/codelite/codelite-11.0.ebuild
@@ -1,45 +1,38 @@
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="6"
 
 WX_GTK_VER="3.0"
-
 inherit cmake-utils wxwidgets
 
 DESCRIPTION="A Free, open source, cross platform C, C++, PHP and Node.js IDE"
-HOMEPAGE="http://www.codelite.org"
+HOMEPAGE="https://www.codelite.org"
 SRC_URI="https://github.com/eranif/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 RESTRICT="primaryuri"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="clang flex mysql pch sftp webview"
+IUSE="clang lldb mysql sftp valgrind"
 
 DEPEND="
-     dev-db/sqlite:*
-
-     net-libs/libssh
-
-     x11-libs/wxGTK:3.0
-
-     mysql? ( virtual/mysql )
+	net-libs/libssh
+	x11-libs/wxGTK:3.0
+	mysql? ( virtual/mysql )
+	valgrind? ( dev-util/valgrind )
 "
 
 RDEPEND="${DEPEND}"
 
-src_prepare() {
-     epatch "${FILESDIR}/codelite_dont_strip.patch"
-}
-
 src_configure() {
-     local mycmakeargs=(
-          $(cmake-utils_use_enable clang CLANG)
-          $(cmake-utils_use_with flex FLEX)
-          $(cmake-utils_use_with mysql MYSQL)
-          $(cmake-utils_use_with pch PCH)
-          $(cmake-utils_use_enable sftp SFTP)
-          $(cmake-utils_use_with webview WEBVIEW)
-     )
+	local mycmakeargs=(
+	-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
+	-DCMAKE_INSTALL_LIBDIR=lib ..
+	-DENABLE_CLANG="$(usex clang)"
+	-DENABLE_LLDB="$(usex lldb)"
+	-DENABLE_MYSQL="$(usex mysql)"
+	-DENABLE_SFTP="$(usex sftp)"
+	)
 
-     cmake-utils_src_configure
+	cmake-utils_src_configure
 }


### PR DESCRIPTION
I made some improvements to make the ebuild pass "repoman -dx full", and removed what appeared to be unneeded dependencies for the latest version. Didn't need the no strip patch for my version but slapping "eapply_user" on it would make it pass with EAPI6 if still needed... :+1: 

Signed-off-by: Bob Brooks <gitbugged@cool.fr.nf>