### PR TITLE
add libXScrnSaver dependency

### DIFF
--- a/app-editors/visual-studio-code/visual-studio-code-1.28.2.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.28.2.ebuild
@@ -22,6 +22,7 @@ DEPEND="
      >=x11-libs/gtk+-2.24.8-r1:2
      x11-libs/cairo
      gnome-base/gconf
+     x11-libs/libXScrnSaver
 "
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
...as vscode won't start without having it installed, see e. g. https://github.com/Microsoft/vscode/issues/15325 :)